### PR TITLE
Rename LAB_ to CAP_

### DIFF
--- a/config/pipeline.sh
+++ b/config/pipeline.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export LAB_PROJECT_NAME="{{project_name}}"
-export LAB_RANDOM_SEED="{{random_seed}}"
+export CAP_PROJECT_NAME="{{project_name}}"
+export CAP_RANDOM_SEED="{{random_seed}}"
 


### PR DESCRIPTION
I forgot to push changes to pipeline.sh to rename environment variables from LAB to CAP.