### PR TITLE
Add latest Bioconductor version to Dockerfile

### DIFF
--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bioconductor/bioconductor_docker:RELEASE_3_17
+FROM bioconductor/bioconductor_docker:{{bioconductor_version}}
 
 
 ##----------------------------------------------------------------------------##


### PR DESCRIPTION
The latest version is determined by using the bioconductor API.

This should correspond to the changes in this CAPTURE pull request and should be approved when it is approved.

https://github.com/lasseignelab/capture/pull/10