### PR TITLE
Update gitignore to container instead of docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 ##########################################################
 
 bin/conda/.conda_env_hashes/
-bin/docker/*.sif
+bin/container/*.sif
 
 data/*
 !data/README


### PR DESCRIPTION
I needed to modify the .gitignore so that the .sif files in bin/container are ignored now that we switch from bin/docker